### PR TITLE
docker: Add root certificates to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,5 +14,6 @@ FROM scratch AS neofs-net-monitor
 WORKDIR /
 
 COPY --from=builder /src/bin/neofs-net-monitor /bin/neofs-net-monitor
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 CMD ["neofs-net-monitor"]


### PR DESCRIPTION
This should fix 
```
can't initialize netmap monitor: can't initialize netmap fetcher: can't create blockchain client: failed to get network magic: Post "https://rpc1.morph.fs.neo.org:40341": x509: certificate signed by unknown authority
```