### PR TITLE
Do not fail on the initial start

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,22 +28,22 @@ image:
 		-t ${REPO}/${APP}:$(HUB_TAG) .
 
 up:
-	$(shell docker-compose -f docker/docker-compose.yml up -d)
+	@docker-compose -f docker/docker-compose.yml up -d
 
 up-testnet:
-	$(shell docker-compose -f docker/docker-compose.testnet.yml up -d)
+	@docker-compose -f docker/docker-compose.testnet.yml up -d
 
 up-devenv:
-	$(shell docker-compose -f docker/docker-compose.devenv.yml up -d)
+	@docker-compose -f docker/docker-compose.devenv.yml up -d
 
 down:
-	$(shell docker-compose -f docker/docker-compose.yml down)
+	@docker-compose -f docker/docker-compose.yml down
 
 down-testnet:
-	$(shell docker-compose -f docker/docker-compose.testnet.yml down)
+	@docker-compose -f docker/docker-compose.testnet.yml down
 
 down-devenv:
-	$(shell docker-compose -f docker/docker-compose.devenv.yml down)
+	@docker-compose -f docker/docker-compose.devenv.yml down
 
 clean:
-	rm ${BINARY}
+	rm -f ${BINARY}


### PR DESCRIPTION
Initial start downdloads missing images. `$(shell docker-compose ...)` catches output of the download progress and tries to interpret it as a command, therefore make execution fails.

Before
```
$ make up-testnet
Creating network "docker_monitor-net" with driver "bridge"
Pulling grafana (grafana/grafana:8.0.6)...
Creating prometheus ... done
Creating neofs-net-monitor ... done
Creating grafana           ... done
8.0.6: Pulling from grafana/grafana Digest: sha256:66c120542437c0d31a76e8370322e6bfcc5c8c78041d9acf9eaa3e2b40f0fe6b Status: Downloaded newer image for grafana/grafana:8.0.6
bash: 8.0.6:: command not found
make: *** [Makefile:31: up] Error 127
```

After
```
$ make up-testnet 
Creating network "docker_monitor-net" with driver "bridge"
Pulling grafana (grafana/grafana:8.0.6)...
8.0.6: Pulling from grafana/grafana
540db60ca938: Pull complete
b1a70ac2e628: Pull complete
b31f6ee16ea8: Pull complete
509c33253828: Pull complete
4d06dfbbc1c3: Pull complete
4f4fb700ef54: Pull complete
f1f6b61b846e: Pull complete
a349d3a4a214: Pull complete
Digest: sha256:66c120542437c0d31a76e8370322e6bfcc5c8c78041d9acf9eaa3e2b40f0fe6b
Status: Downloaded newer image for grafana/grafana:8.0.6
Creating prometheus ... done
Creating grafana           ... done
Creating neofs-net-monitor ... done
```

This fix does not solve `grafana.ini` reading rights issue from https://github.com/nspcc-dev/neofs-net-monitor/pull/31#issuecomment-906556241