### PR TITLE
Supply metrics with new NNS contract support

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ NEOFS_NET_MONITOR_METRICS_ENDPOINT=:16512
 
 // Interval between NeoFS metric scrapping.
 NEOFS_NET_MONITOR_METRICS_INTERVAL=15m
+
+// NeoFS contract from main chain. Required for asset supply metric.
+NEOFS_NET_MONITOR_CONTRACTS_NEOFS=b65d8243ac63983206d17e5221af0653a7266fa1
 ```
 
 To download actual LOCODE database run `$ make locode`.

--- a/docker/docker-compose.testnet.yml
+++ b/docker/docker-compose.testnet.yml
@@ -41,7 +41,9 @@ services:
     environment:
       - NEOFS_NET_MONITOR_MAINNET_RPC_ENDPOINT=https://rpc01.testnet.n3.nspcc.ru:21331
       - NEOFS_NET_MONITOR_MORPH_RPC_ENDPOINT=https://rpc01.morph.testnet.fs.neo.org:51331
+      - NEOFS_NET_MONITOR_METRICS_INTERVAL=15s
       - NEOFS_NET_MONITOR_LOCODE_DB_PATH=locode/db
+      - NEOFS_NET_MONITOR_CONTRACTS_NEOFS=b65d8243ac63983206d17e5221af0653a7266fa1
     volumes:
       - ./../locode/locode_db:/locode/db
     networks:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -41,7 +41,9 @@ services:
     environment:
       - NEOFS_NET_MONITOR_MAINNET_RPC_ENDPOINT=http://rpc10.n3.nspcc.ru:10332
       - NEOFS_NET_MONITOR_MORPH_RPC_ENDPOINT=https://rpc1.morph.fs.neo.org:40341
+      - NEOFS_NET_MONITOR_METRICS_INTERVAL=15s
       - NEOFS_NET_MONITOR_LOCODE_DB_PATH=locode/db
+      - NEOFS_NET_MONITOR_CONTRACTS_NEOFS=2cafa46838e8b564468ebd868dcafdd99dce6221
     volumes:
       - ./../locode/locode_db:/locode/db
     networks:

--- a/docker/grafana/provisioning/dashboards/neofs_dashboard.json
+++ b/docker/grafana/provisioning/dashboards/neofs_dashboard.json
@@ -21,7 +21,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1633620104846,
+  "iteration": 1635789612509,
   "links": [],
   "panels": [
     {
@@ -567,8 +567,8 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 8,
-        "w": 12,
+        "h": 7,
+        "w": 9,
         "x": 0,
         "y": 16
       },
@@ -658,9 +658,9 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
+        "h": 7,
+        "w": 9,
+        "x": 9,
         "y": 16
       },
       "hiddenSeries": false,
@@ -738,6 +738,103 @@
         "align": false,
         "alignLevel": null
       }
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 18,
+        "y": 16
+      },
+      "id": 21,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "neofs_net_monitor_main_chain_supply/1e8",
+          "interval": "",
+          "legendFormat": "Main chain supply",
+          "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "neofs_net_monitor_side_chain_supply/1e12",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Side chain supply",
+          "refId": "B"
+        },
+        {
+          "exemplar": true,
+          "expr": "abs(neofs_net_monitor_main_chain_supply*1e4 - neofs_net_monitor_side_chain_supply)/1e12",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "delta",
+          "refId": "C"
+        }
+      ],
+      "title": "Asset supply",
+      "type": "timeseries"
     },
     {
       "circleMaxSize": "10",

--- a/pkg/monitor/config.go
+++ b/pkg/monitor/config.go
@@ -10,8 +10,10 @@ const (
 	delimiter = "."
 
 	// contracts scripthash
-	cfgNetmapContract = "contracts.netmap"
-	cfgProxyContract  = "contracts.proxy"
+	cfgNetmapContract  = "contracts.netmap"
+	cfgProxyContract   = "contracts.proxy"
+	cfgBalanceContract = "contracts.balance"
+	cfgNeoFSContract   = "contracts.neofs"
 
 	// private key to communicate with blockchain
 	cfgKey = "key"

--- a/pkg/monitor/metrics.go
+++ b/pkg/monitor/metrics.go
@@ -110,4 +110,20 @@ var (
 			Help:      "Side chain GAS amount of proxy contract",
 		},
 	)
+
+	mainChainSupply = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Subsystem: "neofs_net_monitor",
+			Name:      "main_chain_supply",
+			Help:      "Main chain GAS amount of neofs contract",
+		},
+	)
+
+	sideChainSupply = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Subsystem: "neofs_net_monitor",
+			Name:      "side_chain_supply",
+			Help:      "Side chain total supply of balance contract",
+		},
+	)
 )

--- a/pkg/morphchain/balance.go
+++ b/pkg/morphchain/balance.go
@@ -56,3 +56,7 @@ func (b BalanceFetcher) FetchGASByScriptHash(sh util.Uint160) (int64, error) {
 func (b BalanceFetcher) FetchNotaryByScriptHash(sh util.Uint160) (int64, error) {
 	return b.cli.NEP17BalanceOf(b.notary, sh)
 }
+
+func (b BalanceFetcher) FetchNEP17TotalSupply(tokenHash util.Uint160) (int64, error) {
+	return b.cli.NEP17TotalSupply(tokenHash)
+}


### PR DESCRIPTION
Closes #45 
Closes #49 

Supply feature **requires** NeoFS contract address in config. It is not stored in NNS contract, thus it should be specified manually.

![image](https://user-images.githubusercontent.com/6323066/139722981-4f4083d5-4cdc-48b6-87a2-d7ca014aa238.png)

Testnet has some divergence due to alphabet RPC nodes outage. Mainnet looks as expected.