### PR TITLE
cmd: disable zap log sampling

### DIFF
--- a/cmd/neo-exporter/monitor.go
+++ b/cmd/neo-exporter/monitor.go
@@ -27,6 +27,7 @@ func New(ctx context.Context, cfg *viper.Viper) (*monitor.Monitor, error) {
 		logConf.EncoderConfig.EncodeTime = func(_ time.Time, _ zapcore.PrimitiveArrayEncoder) {}
 	}
 	logConf.Level = WithLevel(cfg.GetString(cfgLoggerLevel))
+	logConf.Sampling = nil
 	logger, err := logConf.Build()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Skipping log lines is not safe to be used by default. Notice that s3-authmate doesn't have this problem because of the way it constructs its settings.

See also:
 * https://github.com/nspcc-dev/neofs-node/pull/3011
 * https://github.com/nspcc-dev/neo-go/pull/598